### PR TITLE
to-keyword receiving nil returns nil instead of an unreadable keyword

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ontodev/excel "0.2.6"
+(defproject ontodev/excel "0.2.7"
   :description "A thin Clojure wrapper around a small part of Apache POI for
                 reading .xlsx files."
   :url "http://github.com/ontodev/excel"

--- a/src/ontodev/excel.clj
+++ b/src/ontodev/excel.clj
@@ -51,6 +51,7 @@
       string/trim
       string/lower-case
       (string/replace #"\s+" "-")
+      not-empty
       keyword))
 
 ;; Note: it would make sense to use the iterator for the row. However that

--- a/test/ontodev/excel_test.clj
+++ b/test/ontodev/excel_test.clj
@@ -1,6 +1,15 @@
 (ns ontodev.excel-test
+  (:require [clojure.test :refer :all])
   (:use midje.sweet
         ontodev.excel))
+
+(deftest test-to-keyword-takes-nil
+  (is (nil? (to-keyword nil))))
+
+(deftest test-to-keyword-valid
+  (is (= :keyword-one (to-keyword "keyword one")))
+  (is (= :keyword-one (to-keyword "Keyword One")))
+  (is (= :keyword-one (to-keyword "   KeyWord oNe   "))))
 
 (defn check-row
   [row]


### PR DESCRIPTION
Currently if `to-keyword` takes nil as an argument an unreadable keyword `:` is returned (the result of calling `keyword` on an empty string).  I don't think this behavior is as useful as just returning nil (harder to compare against), and an unreadable keyword is an effectively invalid result.

https://clojure.org/guides/faq#unreadable_keywords
